### PR TITLE
Point extend_msgs at main: master is a dead ref

### DIFF
--- a/deps.repos
+++ b/deps.repos
@@ -1,4 +1,4 @@
 - git:
     local-name: extend_msgs
     uri: https://github.com/Extend-Robotics/extend_msgs.git
-    version: master
+    version: main


### PR DESCRIPTION
## What

Points the `extend_msgs` entry in `deps.repos` at `main`: `master` is a dead ref since the extend_msgs branch renames (ERD-2166), so any recursive vcs/rv import following this file 404s. The already-renamed sibling branches (xarm_ros@ERD-1577_no_moveit, extend_bio_ik@new_arch_devel) pin `main`.

Today's image builds survive only because the top-level pin sets override this transitive entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


